### PR TITLE
Simplify ScopeGuard usage and allow arbitrary return types

### DIFF
--- a/tests/utility.cpp
+++ b/tests/utility.cpp
@@ -10,6 +10,16 @@ int main () {
       bool value { false };
       { auto scope = core::make_scope_guard([&]{ value = true; }); }
       assert::is_true(value);
+    },
+    task("constructor") = [] {
+      bool value { false };
+      { core::scope_guard guard([&] { value = true;}); }
+      assert::is_true(value);
+    },
+    task("ignore-return") = [] {
+      bool value { false };
+      { core::scope_guard guard([&] { return value = true;}); }
+      assert::is_true(value);
     }
   };
 


### PR DESCRIPTION
Since `Callable` is required to take no arguments and ignores the return type it can simply take `std::function<void()>` as it's argument and wrap other function types using `std::bind` (allows for move semantics for lambda captures in C++11).

Because the constructor is now a template instead of the class you can eliminated the need for `auto` and `make_scope_guard` and simply use the default constructor (less copying this way and looks cleaner in my opinion).

All previous use of `make_scope_guard` will still work.

New Syntax:

```
scope_guard guard([&] { value = true;});
// also supports
scope_guad guard([&] { value = true; return 1; /* any return will work */; });
```

Tests are passing on OSX (XCode, Clang)
