### PR TITLE
Fix storage move constructor

### DIFF
--- a/include/core/optional.hpp
+++ b/include/core/optional.hpp
@@ -105,9 +105,9 @@ struct storage<T, true> {
     engaged { that.engaged }
   {
     if (not this->engaged) { return; }
-    ::new(::std::addressof(this->val)) value_type {
+    ::new(::std::addressof(this->val)) value_type (
       ::core::move(that.val)
-    };
+    );
   }
 
   constexpr storage (value_type const& value) :


### PR DESCRIPTION
Stop compiler from thinking we're trying to use an initializer list

Repro:

```
#include <core/optional.hpp>

struct A {};

core::optional<A> foo() {
    return core::nullopt;
}

int main() {                                                                                                                                                                                                                                                                                                                                                                
    const auto a = foo();
}
```

```
g++ -std=c++11 const.cc 
In file included from const.cc:1:0:
/usr/include/core/optional.hpp: In instantiation of ‘core::v1::impl::storage<T, true>::storage(core::v1::impl::storage<T, true>&&) [with T = A]’:
/usr/include/core/optional.hpp:193:3:   required from here
/usr/include/core/optional.hpp:108:5: error: could not convert ‘{core::v1::move<A&>((* & that.core::v1::impl::storage<A, true>::<anonymous>.core::v1::impl::storage<A, true>::<anonymous union>::val))}’ from ‘<brace-enclosed initializer list>’ to ‘core::v1::impl::storage<A, true>::value_type {aka A}’
     ::new(::std::addressof(this->val)) value_type {
     ^
```

```
clang -std=c++11 const.cc 
In file included from const.cc:1:
/usr/include/core/optional.hpp:109:7: error: excess elements in struct initializer
      ::core::move(that.val)
      ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/core/optional.hpp:193:3: note: in instantiation of member function 'core::v1::impl::storage<A, true>::storage' requested here
  optional (optional&&) = default;
  ^
1 error generated.
```

I find it really annoying that neither g++ or clang references the line of code in my example that triggers this error.
