### PR TITLE
Biicode initial support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 build-clang/
 build-gcc/
 build/
+
+bii/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build-gcc/
 build/
 
 bii/
+bin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.0.0)
 project(core VERSION 1.2.0.0 LANGUAGES CXX)
 
 #------------------------------------------------------------------------------
@@ -37,6 +37,13 @@ cmake_dependent_option(BUILD_PACKAGE_MSI "Create an MSI" ON "${MSI_DEP}" OFF)
 cmake_dependent_option(BUILD_PACKAGE_RPM "Create an RPM" ON "${RPM_DEP}" OFF)
 cmake_dependent_option(BUILD_PACKAGE_PKG "Create a PKG" ON "${PKG_DEP}" OFF)
 cmake_dependent_option(BUILD_WITH_LIBCXX "Use libc++" OFF "BUILD_TESTING" OFF)
+
+IF(BIICODE)
+  ADD_BIICODE_TARGETS()
+  INCLUDE(biicode/cmake/tools)
+  ACTIVATE_CPP11(INTERFACE ${BII_BLOCK_TARGET})
+  return()
+ENDIF()
 
 #------------------------------------------------------------------------------
 # Configuration

--- a/biicode.conf
+++ b/biicode.conf
@@ -9,7 +9,6 @@
 
 [mains]
     tests/*.cpp
-    !tests/memory.cpp
 
 [tests]
     tests/*

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,0 +1,18 @@
+# Biicode configuration file
+
+[requirements]
+	 biicode/cmake: 3
+	 diego/catch: 0
+
+[paths]
+    include
+
+[mains]
+    tests/*.cpp
+    !tests/memory.cpp
+
+[tests]
+    tests/*
+
+[includes]
+    catch.hpp: diego/catch


### PR DESCRIPTION
Hi Izzy,

This is an informative PR, it is ok to disregard it, just for demostrative purposes.
I am able to work (with last 2.6.3 version) with this repo in Ubuntu 14, gcc 4.8 with the following:
```
$ git clone https//github.com/drodri/core.git
$ cd core
$ bii init -L
$ bii test (this will build the test and run them)
```
Then I am able to publish (to my user in this case,  http://www.biicode.com/diego/core, just DEV version will delete it when you have yours)
```
$ bii publish
```
After that, I am able to create a new project:
```
$ cd ..
$ bii init myproject -L
$ cd myproject
```

Write there:
```
#include <iostream>
#include "diego/core/include/core/algorithm.hpp"

int main() {
  std::cout << "Hello world!\n";
  std::vector<int> values { 1, 2, 3, 4, 5 };
  auto result = core::any_of(values, [](int v) { return v % 2 == 0; });
  std::cout<< result<< "\n";
}
```

```
$ bii find
$ bii build
$ bin/diego_myproject_main
```

Voila! :) :) :)


Now the changes required:

1. gitignoring bii aux folders
2. Sorry, my mistake downgrading cmake, not really necessary, just because most biicode users will have something >3.0 so 3.1 might fail for many. I had installed 3.0 so I required to change it.
3. ADD_BIICODE_TARGETS. To activate C++11 I have used a macro for convenience defined in http://www.biicode.com/biicode/cmake (The cmake INCLUDE, biicode is also able to use it to retrieve cmake scripts from previously published projects)
4. The biicode.conf [requirements]. I saw you are depending on catch, but the biicode copy is not working properly. We have notified the orignal author to fix it, but in the mean time I have just uploaded a catch single header to my profile, for demostration purposes. The other requirement is the one for the cmake script, but is not strictly necessary if you dont use the ACTIVATE_CPP11 macro and do it manually.
5 The biicode.conf [paths] define include paths for files INSIDE the block (the tests).
6. The biicode.conf [mains] section defines everything that is an entry point (typically auto-computed from main()), as these files dont have it defined, but including catch one, it is necessary to tell biicode.
7. biicode.conf [tests] section labels everything under those pattterns to not be included in the lib, and group them and build them with the "check" target (--target check) or the simpler "bii test" or "bii cpp:test" alias.
8. Finally the [includes] section is a map to external dependencies. Everywhere it finds a "catch.hpp" include, it will map it to my block. This is extremely useful in case you want to swap implementation or components, it is straightforward: just map the include and indicate the version you want in [requirements]
```
[includes]
    cath.hpp: otheruser/othercatch
[requirements]
    otheruser/othercatch: 8
```

This is an initial point, I wanted to show some of the biicode features and clarify some ideas. It is interesting that biicode in this setup does not require any other of the CMakeLists, for example the one inside the tests folder.
But if the options are to be taken into account, they have to be added to the cmake files. 
The best thing is this is being a very useful process for me to help me understand how to explain things. Now we are going back to improve the docs with these learnings.
Tested in mingw4.8, and still some test build fails: functional.cpp:108:41: error: 'to_string' is not a member of 'std'

Best

