### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,7 +72,8 @@ function(add_unit_test name file)
     $<$<BOOL:${CAN_SANITIZE_UNDEFINED}>:${SANITIZE_UNDEFINED}>
     $<$<BOOL:${CAN_SANITIZE_ADDRESS}>:${SANITIZE_ADDRESS}>
     $<$<BOOL:${CAN_SANITIZE_MEMORY}>:${SANITIZE_MEMORY}>
-    $<$<BOOL:${BUILD_WITH_COVERAGE}>:${USE_COVERAGE}>)
+    $<$<BOOL:${BUILD_WITH_COVERAGE}>:${USE_COVERAGE}>
+    $<$<AND:${LIBCXX}>:${USE_STDLIB_LIBCXX}>)
 endfunction ()
 
 #------------------------------------------------------------------------------
@@ -123,11 +124,7 @@ if (MSVC)
   set(WARN_ALL "/W4")
 endif ()
 
-# Only for when using certain cmake versions (like the ones found on travis-ci)
-if (${CMAKE_VERSION} VERSION_LESS "3.1.0" OR "$ENV{TRAVIS}" STREQUAL "true")
-  check_cxx_compiler_flag(${USE_STD_CXX11} CAN_USE_STD_CXX11)
-endif ()
-
+check_cxx_compiler_flag(${USE_STD_CXX11} CAN_USE_STD_CXX11)
 check_cxx_compiler_flag(${USE_STDLIB_LIBCXX} CAN_USE_STDLIB_LIBCXX)
 check_cxx_compiler_flag(${USE_NO_RTTI} CAN_USE_NO_RTTI)
 


### PR DESCRIPTION
To link against libc++ the library has to appear in the link options - default is libstdc++ which leads to undefined references.

Further the check for c++11 has to be done every time - without that check the USE_STD_CXX11 variable is not set and the include header are not found.

This was tested with clang 3.6.2 and cmake 3.2.2 on Ubuntu 14.04
