### PR TITLE
Fix string_view::max_size()

### DIFF
--- a/include/core/string_view.hpp
+++ b/include/core/string_view.hpp
@@ -201,7 +201,7 @@ struct basic_string_view {
   const_reverse_iterator crbegin () const noexcept { return this->rbegin(); }
   const_reverse_iterator crend () const noexcept { return this->rend(); }
 
-  constexpr size_type max_size () const noexcept { return this->size(); }
+  constexpr size_type max_size () const noexcept { return ::std::numeric_limits<size_type>::max(); }
   constexpr size_type length () const noexcept { return this->size(); }
   constexpr size_type size () const noexcept { return this->len; }
 

--- a/tests/string-view.cpp
+++ b/tests/string-view.cpp
@@ -97,7 +97,7 @@ TEST_CASE("string-view-methods", "[string-view][methods]") {
   SECTION("max-size") {
     constexpr core::string_view ref { };
 
-    CHECK(ref.max_size() == 0u);
+    CHECK(ref.max_size() == ::std::numeric_limits<core::string_view::size_type>::max());
   }
 
   SECTION("size") {


### PR DESCRIPTION
Previously, string_view::max_size() would return the size of the view whereas it
should have returned the largest possible string_view that could be constructed.

This patch addresses the issue by properly returning the maximum size of a
string_view.

Additionally, this should close #46 