### PR TITLE
Remove memory.hpp's dependency on algorithm.hpp

### DIFF
--- a/include/core/memory.hpp
+++ b/include/core/memory.hpp
@@ -9,7 +9,6 @@
 #include <cstdlib>
 
 #include <core/type_traits.hpp>
-#include <core/algorithm.hpp>
 #include <core/range.hpp>
 
 #ifndef CORE_NO_EXCEPTIONS


### PR DESCRIPTION
MSVC 2015 Update 3 chokes on compiling algorithm.hpp.  memory.hpp doesn't use any functionality from algorithm.hpp, and removing this unnecessary dependency allows for a successful build of the former with this compiler.